### PR TITLE
CR 1.0.4 Fixing Issue #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ http://jsfiddle.net/thekenwheeler/32hgqsxt/
 
 ### Instantiating Flaxs
 
-There are 3 ways to have a Flaxs instance fluxing the application:
+There are 2 ways to have a Flaxs instance fluxing the application:
 
 ```javascript
 import Flaxs from 'flaxs';
@@ -262,11 +262,4 @@ or
 import { flaxs } from 'flaxs';
 
 // const flaxs contains an already instantiated Flaxs() object with an empty initialState;
-```
-or
-```javascript
-import { createStore } from 'flaxs';
-
-const flaxs = createStore({ ...initialState });
-// flaxs object will be the already instantiated Flaxs() instance, so you don't have to create a 'new' one;
 ```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "contributors": [
     "Ken Wheeler",
     "JC Perez Chavez <jc.perezchavez@gmail.com>",
-    "Thomas Andreo",
+    "Thomas Andreo"
   ],
   "repository": {
     "type": "git",

--- a/src/__tests__/Store-test.js
+++ b/src/__tests__/Store-test.js
@@ -8,9 +8,8 @@ jest.dontMock('../Dispatcher');
 describe('Store', () => {
 
   const { default: Store } = require('../Store');
-  const Flaxs = require('../Flaxs').default;
+  const { flaxs } = require('../Flaxs');
   const { includes, union, isEqual } = require('lodash');
-  let flaxs = new Flaxs();
 
   const mockStore = new Store({
     testMethod: () => true,
@@ -121,15 +120,13 @@ describe('Store', () => {
   });
 
   describe('MasterStore', () => {
-    const { createStore } = require('../Flaxs');
-
     beforeEach(() => {
-      flaxs = createStore({ name: 'test' });
+      flaxs.store.mergeState('startingWith', 'test');
     });
 
     it('should have an already defined store', () => {
       expect(flaxs.store.state).toBeDefined();
-      expect(flaxs.store.state.name).toBe('test');
+      expect(flaxs.store.state.startingWith).toBe('test');
     });
 
     it('should merge states', () => {
@@ -145,7 +142,7 @@ describe('Store', () => {
       } });
 
       expect(Object.isFrozen(flaxs.store.state)).toBe(true);
-      expect(Object.isFrozen(flaxs.store.state.name)).toBe(true);
+      expect(Object.isFrozen(flaxs.store.state.startingWith)).toBe(true);
       expect(Object.isFrozen(flaxs.store.state.user)).toBe(true);
       expect(Object.isFrozen(flaxs.store.state.user.info)).toBe(false);
     });


### PR DESCRIPTION
Fixing bug where multi emit events when dispatching action types in multiple reducers.

Adding a unit test regarding that.... basically I freeze the initial state if there is a reducer dispatched when the first reducer is dispatching, then we do the changes on the state every time it actually requires the change, and finally when all reducers are finished we compare frozenStore with current store... if changed then we emit a change in a single dispatch.
