### PR TITLE
Allow the creation of synchronous actions

### DIFF
--- a/src/Action.js
+++ b/src/Action.js
@@ -19,8 +19,9 @@ class Action {
    * @param {function} callback - Callback method for Action
    * @constructor
    */
-  constructor(callback) {
+  constructor(callback, actionName) {
     this.callback = callback;
+    this.actionName = actionName;
   }
 
 
@@ -47,6 +48,19 @@ class Action {
         resolve();
         return true;
       }));
+  }
+
+  syncDispatch() {
+    const payload = this.callback.apply(this, arguments);
+    const reject = () => true;
+    if (!payload) return reThrow(reject, 'Payload needs to be an object');
+    if (!payload.actionType) return reThrow(reject, 'Payload object requires an actionType property');
+
+    try {
+      Dispatcher.dispatch(payload);
+    } catch (error) {
+      reThrow(reject, error);
+    }
   }
 }
 

--- a/src/ActionsFactory.js
+++ b/src/ActionsFactory.js
@@ -13,10 +13,11 @@ export default class ActionsFactory {
    * @param {object} actions - Object with methods to create actions with
    * @constructor
    */
-  constructor(actions) {
+  constructor(actions, isAsync = true) {
     forEach(actions, (actionCallback, actionName) => {
-      const action = new Action(actionCallback);
-      this[actionName] = action.dispatch.bind(action);
+      const action = new Action(actionCallback, actionName);
+
+      this[actionName] = isAsync ? action.dispatch.bind(action) : action.syncDispatch.bind(action);
     });
   }
 }

--- a/src/Flaxs.js
+++ b/src/Flaxs.js
@@ -45,8 +45,8 @@ class Flaxs {
    * @param {object} actions - Action methods
    * @return {object} - Returns instance of ActionsFactory
    */
-  createActions(actions) {
-    const actionFactory = new ActionsFactory(actions);
+  createActions(actions, isAsync = true) {
+    const actionFactory = new ActionsFactory(actions, isAsync);
     assign(this.actions, actionFactory);
     return actionFactory;
   }

--- a/src/__tests__/ActionsFactory-test.js
+++ b/src/__tests__/ActionsFactory-test.js
@@ -25,4 +25,22 @@ describe('ActionsFactory', () => {
     expect(mockActionsFactory.testMethodB).toBeDefined();
   });
 
+  it('create new synchronous Actions', () => {
+
+    mockActionsFactory = new ActionsFactory({
+      testMethodA: () => ({
+        actionType: 'TEST_ACTION_A',
+        data: arguments,
+      }),
+      testMethodB: () => ({
+        actionType: 'TEST_ACTION_B',
+        data: arguments,
+      }),
+    }, false);
+
+    expect(mockActionsFactory.testMethodA).toBeDefined();
+    expect(mockActionsFactory.testMethodB).toBeDefined();
+
+  });
+
 });

--- a/src/__tests__/Flaxs-test.js
+++ b/src/__tests__/Flaxs-test.js
@@ -10,7 +10,7 @@ jest.dontMock('../Dispatcher');
 
 describe('Flaxs', () => {
 
-  const Flaxs = require('../Flaxs').default;
+  const { flaxs } = require('../Flaxs');
   const Store = require('../Store').default;
   const ActionsFactory = require('../ActionsFactory').default;
   const TestConstants = {
@@ -20,8 +20,6 @@ describe('Flaxs', () => {
   };
 
   const testItems = [];
-
-  const flaxs = new Flaxs();
 
   const mockStore = flaxs.createStore({
     getItems: () => testItems,
@@ -54,6 +52,17 @@ describe('Flaxs', () => {
       value,
     }),
   });
+
+  const mockSyncActionsFactory = flaxs.createActions({
+    add: (item) => ({
+      actionType: TestConstants.TEST_ADD,
+      item,
+    }),
+    remove: (item) => ({
+      actionType: TestConstants.TEST_REMOVE,
+      item,
+    }),
+  }, false);
 
   flaxs.createReducer('reducer', (state, { actionType, item }) => {
     switch (actionType) {
@@ -178,5 +187,17 @@ describe('Flaxs', () => {
     await mockActionsFactory.consume(5);
     expect(flaxs.store.state.flags).toEqual({ consumed: 2 });
     expect(flaxs.store.emitChange.mock.calls.length).toBe(3);
+  });
+
+  it('should synchronously dispatch actions', () => {
+
+    const testItem = 2;
+
+    expect(flaxs.store.state.reducer.adds).toEqual(6);
+    mockSyncActionsFactory.add(testItem);
+    expect(flaxs.store.state.reducer.adds).toEqual(8);
+
+    mockSyncActionsFactory.remove(testItem);
+    expect(flaxs.store.state.reducer.removes).toEqual(8);
   });
 });


### PR DESCRIPTION
Fixes issue https://github.com/jcperez-ch/flaxs/issues/9 by adding a second parameter to allow synchronous dispatching, now we can assure that action invocations and master store changes are synchronized by creating our actions like:

``` js
let mockSyncActionsFactory = flaxs.createActions({
    add: function(item) {
      return {
        actionType: TestConstants.TEST_ADD,
        item,
      }
    },
    remove: function(item) {
      return {
        actionType: TestConstants.TEST_REMOVE,
        item,
      }
    }
  }, false
);
```

The first parameter of `flaxs.createActions` is still the object with callback definitions and the second parameter is a boolean (by default `true`) that flags the actions as asynchronous if true.
